### PR TITLE
Added Gmail Bounce Support To BodyRules

### DIFF
--- a/src/BounceMailHandler/phpmailer-bmh_rules.php
+++ b/src/BounceMailHandler/phpmailer-bmh_rules.php
@@ -102,7 +102,19 @@ function bmhBodyRules($body, $structure, $debug_mode = false)
   elseif (preg_match("/no\s+such\s+address\s+here/i", $body, $match)) {
     $result['rule_cat'] = 'unknown';
     $result['rule_no'] = '0237';
-  } /* rule: unknown
+  }
+  /* Gmail Bounce Error
+   * rule: unknown
+   * sample:
+   *   Delivery to the following recipient failed permanently:
+   *   xxxxx@yourdomain.com
+   */
+  elseif (preg_match("/Delivery to the following (?:recipient|recipients) failed permanently\X*?(\S+@\S+\w)/i", $body, $match)) {
+    $result['rule_cat'] = 'unknown';
+    $result['rule_no'] = '0998';
+	  $result['email'] = $match[1];
+  }
+  /* rule: unknown
    * sample:
    *   <xxxxx@yourdomain.com>:
    *   111.111.111.111 does not like recipient.

--- a/src/BounceMailHandler/phpmailer-bmh_rules.php
+++ b/src/BounceMailHandler/phpmailer-bmh_rules.php
@@ -112,7 +112,7 @@ function bmhBodyRules($body, $structure, $debug_mode = false)
   elseif (preg_match("/Delivery to the following (?:recipient|recipients) failed permanently\X*?(\S+@\S+\w)/i", $body, $match)) {
     $result['rule_cat'] = 'unknown';
     $result['rule_no'] = '0998';
-	  $result['email'] = $match[1];
+    $result['email'] = $match[1];
   }
   /* rule: unknown
    * sample:


### PR DESCRIPTION
Added Gmail bounce support to BodyRules. I have tested in my development environment and found no issues, I also tested the regex expression with an online tool against multiple types of bounced emails all from Gmail and the regex has passed for all the emails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/phpmailer-bmh/5)
<!-- Reviewable:end -->
