### PR TITLE
Fixed warning "imap_header(): Bad message number" in the case of moving messages

### DIFF
--- a/src/BounceMailHandler/BounceMailHandler.php
+++ b/src/BounceMailHandler/BounceMailHandler.php
@@ -498,6 +498,8 @@ class BounceMailHandler
       }
     }
 
+    $fetchedCountOutput = $fetchedCount;
+
     for ($x = 1; $x <= $fetchedCount; $x++) {
 
       // fetch the messages one at a time
@@ -635,6 +637,11 @@ class BounceMailHandler
         $moveFlag[$x] = true;
       }
 
+      if ($deleteFlag[$x] || $moveFlag[$x]) {
+        --$x;
+        --$fetchedCount;
+      }
+
       flush();
     }
 
@@ -644,7 +651,7 @@ class BounceMailHandler
     @imap_expunge($this->mailboxLink);
     imap_close($this->mailboxLink);
 
-    $this->output('Read: ' . $fetchedCount . ' messages');
+    $this->output('Read: ' . $fetchedCountOutput . ' messages');
     $this->output($processedCount . ' action taken');
     $this->output($unprocessedCount . ' no action taken');
     $this->output($deletedCount . ' messages deleted');


### PR DESCRIPTION
If I set move* flags in true (`moveSoft` and `moveHard`) and I have more than one message in INBOX than I have PHP warning (after calling `processMailbox()`):

> PHP Warning 'yii\base\ErrorException' with message 'imap_header(): Bad message number'
> in /app/vendor/voku/bounce-mail-handler/src/BounceMailHandler/BounceMailHandler.php:691
>
> Stack trace:
> #0 /app/vendor/voku/bounce-mail-handler/src/BounceMailHandler/BounceMailHandler.php(536): BounceMailHandler\BounceMailHandler->processBounce()

The function is stopped in spite of the fact that this warning. So, it brings inconvenience.
I tried to solve the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/phpmailer-bmh/11)
<!-- Reviewable:end -->
