### PR TITLE
Minor adjustments

### DIFF
--- a/src/BounceMailHandler/BounceMailHandler.php
+++ b/src/BounceMailHandler/BounceMailHandler.php
@@ -311,7 +311,7 @@ class BounceMailHandler
     public function globalDelete(): bool
     {
         $dateArr = \explode('-', $this->deleteMsgDate); // date format is yyyy-mm-dd
-        $delDate = \mktime(0, 0, 0, $dateArr[1], $dateArr[2], $dateArr[0]);
+        $delDate = \mktime(0, 0, 0, intval($dateArr[1]), intval($dateArr[2]), intval($dateArr[0]));
 
         $port = $this->port . '/' . $this->service . '/' . $this->serviceOption;
         $mboxt = \imap_open('{' . $this->mailhost . ':' . $port . '}', $this->mailboxUserName, $this->mailboxPassword, OP_HALFOPEN);

--- a/src/BounceMailHandler/BounceMailHandler.php
+++ b/src/BounceMailHandler/BounceMailHandler.php
@@ -817,7 +817,7 @@ class BounceMailHandler
                 $header = \imap_fetchheader($this->mailboxLink, $x);
 
                 // Could be multi-line, if the new line begins with SPACE or HTAB
-                if (\preg_match("/Content-Type:((?:[^\n]|\n[\t ])+)(?:\n[^\t ]|$)/i", $header, $match)) {
+                if ($header && \preg_match("/Content-Type:((?:[^\n]|\n[\t ])+)(?:\n[^\t ]|$)/i", $header, $match)) {
                     if (
                         \preg_match("/multipart\/report/i", $match[1])
                         &&

--- a/src/BounceMailHandler/BounceMailHandler.php
+++ b/src/BounceMailHandler/BounceMailHandler.php
@@ -342,15 +342,21 @@ class BounceMailHandler
                     }
 
                     \imap_expunge($mboxd);
+                    \imap_errors();
+                    \imap_alerts();
                     \imap_close($mboxd);
                 }
             }
 
+            \imap_errors();
+            \imap_alerts();
             \imap_close($mboxt);
 
             return true;
         }
 
+        \imap_errors();
+        \imap_alerts();
         \imap_close($mboxt);
 
         return false;
@@ -421,16 +427,22 @@ class BounceMailHandler
             if ($mailboxFound === false && $create) {
                 /** @noinspection PhpUsageOfSilenceOperatorInspection */
                 @\imap_createmailbox($mbox, \imap_utf7_encode('{' . $this->mailhost . ':' . $port . '}' . $mailbox));
+                \imap_errors();
+                \imap_alerts();
                 \imap_close($mbox);
 
                 return true;
             }
 
+            \imap_errors();
+            \imap_alerts();
             \imap_close($mbox);
 
             return false;
         }
 
+        \imap_errors();
+        \imap_alerts();
         \imap_close($mbox);
 
         return false;


### PR DESCRIPTION
Good morning,


We are providing some minor corrections that we have found useful in our systems.

1 - Adding the calls to the functions **imap_errors()** and **imap_alerts()** before all thecalls to the function **imap_close()**. They were originating warnings in our systems.

More information
http://php.net/manual/en/function.imap-alerts.php
http://php.net/manual/en/function.imap-errors.php

2 - Correcting a fatal error originated by passing a wrongly formatted date in the $this->deleteMsgDate parameter.

3 - Correcting another fatal error on preg_match() when $heades is void.

We hope you find these fixes useful so they can be added to the master repository.

Francesc X Escarmís
Clickedu Team

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/phpmailer-bmh/14)
<!-- Reviewable:end -->
