### PR TITLE
Pass message id to imap_delete as string instead of int

### DIFF
--- a/src/BounceMailHandler/BounceMailHandler.php
+++ b/src/BounceMailHandler/BounceMailHandler.php
@@ -876,7 +876,7 @@ class BounceMailHandler
                     // delete the bounce if not in disableDelete mode
                     if (!$this->testMode) {
                         /** @noinspection PhpUsageOfSilenceOperatorInspection */
-                        @\imap_delete($this->mailboxLink, $x);
+                        @\imap_delete($this->mailboxLink, (string)$x);
                     }
 
                     $deleteFlag[$x] = true;
@@ -917,7 +917,7 @@ class BounceMailHandler
                     // delete this bounce if not in disableDelete mode, and the flag BOUNCE_PURGE_UNPROCESSED is set
                     if (!$this->testMode) {
                         /** @noinspection PhpUsageOfSilenceOperatorInspection */
-                        @\imap_delete($this->mailboxLink, $x);
+                        @\imap_delete($this->mailboxLink, (string)$x);
                     }
 
                     $deleteFlag[$x] = true;


### PR DESCRIPTION
This avoids error "imap_delete(): Argument #2 ($message_num) must be of type string, int given"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/phpmailer-bmh/17)
<!-- Reviewable:end -->
